### PR TITLE
Fix 'Principal' title in resume files

### DIFF
--- a/public/resume.json
+++ b/public/resume.json
@@ -19,7 +19,7 @@
   ],
   "Preferences":
   {
-           "Title": "Architect/Principle/Staff/Senior Software Developer/Engineer",
+           "Title": "Architect/Principal/Staff/Senior Software Developer/Engineer",
         "Emphasis": [ "Mobile", "Java", "Kotlin", "Python", "C++", "C#", "Qt" ],
     "Technologies": [ "AI", "Android", "Audio/Video", "Embedded", "IoT", "Mobile", "RTC/WebRTC", "Streaming" ],
        "Locations": ["Seattle", "Denver", "Nashville"]

--- a/public/resume.yaml
+++ b/public/resume.yaml
@@ -13,7 +13,7 @@ Summary:
   - user-friendly applications and learning new technologies.
 
 Preferences:
-  Title: Architect/Principle/Staff/Senior Software Developer/Engineer
+  Title: Architect/Principal/Staff/Senior Software Developer/Engineer
   Salary: $200K+ (negotiable)
   Emphasis: [ Mobile, Android, Java, Kotlin, Python, C++, C#, Qt ]
   Technologies: [ AI, Android, Audio/Video, Embedded, IoT, Mobile, RTC/WebRTC, Streaming ]


### PR DESCRIPTION
## Summary
- correct spelling of *Principal* in the Preferences section of both resume files

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6849f26109d0833385531fc0c21bf135