### PR TITLE
Support mode selection via URL parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Production version at:
 ## Why?
 https://swooby.com/pv/resume.2024/resume_reaction.wav
 
+## Modes
+The resume can be shown in different modes by adding a query parameter to the URL:
+
+* `?mode=recruiter` – show the recruiter view (default)
+* `?mode=everything` – show all details
+
 ## Development
 * `npm i`
 * `npm run dev`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -294,7 +294,14 @@ function RenderContact({ contactName, contact, summary }: RenderContactProps) {
 }
 
 function App() {
-  const defaultMode = "modeRecruiter";
+  const defaultMode = (() => {
+    const params = new URLSearchParams(window.location.search)
+    const queryMode = params.get("mode")
+    if (queryMode === "everything") {
+      return "modeEverything"
+    }
+    return "modeRecruiter"
+  })();
   const [expandedExperience, setExpandedExperience] = useState<Record<number,boolean>>({});
   const toggleExperience = (idx: number) =>
     setExpandedExperience(e => ({ ...e, [idx]: !e[idx] }));


### PR DESCRIPTION
## Summary
- allow selecting recruiter or everything mode through `?mode` query string
- document `mode` URL parameter in README
- simplify mode query parameter parsing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 19 problems (18 errors, 1 warning))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a696775a748333bcad21bda54a2b5c